### PR TITLE
Added file k8s-master.sh

### DIFF
--- a/k8s-master.sh
+++ b/k8s-master.sh
@@ -1,0 +1,51 @@
+# set hostname
+hostnamectl set-hostname kmaster
+
+# for testing
+ufw disable
+
+# off swap
+swapoff -a; sed -i '/swap/d' /etc/fstab
+
+# Update sysctl settings for Kubernetes networking
+cat >>/etc/sysctl.d/kubernetes.conf<<EOF
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+EOF
+sysctl --system
+
+# Install docker engine
+{
+  apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  apt update
+  apt install -y docker-ce=5:19.03.10~3-0~ubuntu-focal containerd.io
+  groupadd docker
+  usermod -aG docker $USER
+}
+
+# Add Apt repository
+{
+  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+  echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+}
+
+# Install Kubernetes components
+apt update && apt install -y kubeadm=1.18.5-00 kubelet=1.18.5-00 kubectl=1.18.5-00
+
+# Initialize Kubernetes Cluster
+mgmtip=$(hostname -I | cut -d' ' -f1-1)
+kubeadm init --apiserver-advertise-address=$mgmtip --pod-network-cidr=192.168.0.0/16  --ignore-preflight-errors=all
+
+# Deploy Calico network
+kubectl --kubeconfig=/etc/kubernetes/admin.conf create -f https://docs.projectcalico.org/v3.14/manifests/calico.yaml
+
+# To be able to run kubectl commands as non-root user
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+# Cluster join command
+# Note this Command
+kubeadm token create --print-join-command

--- a/k8s-worker.sh
+++ b/k8s-worker.sh
@@ -1,0 +1,37 @@
+# set hostname
+# needs to be different for different workers
+hostnamectl set-hostname kworker
+
+# for testing
+ufw disable
+
+# off swap
+swapoff -a; sed -i '/swap/d' /etc/fstab
+
+# Update sysctl settings for Kubernetes networking
+cat >>/etc/sysctl.d/kubernetes.conf<<EOF
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+EOF
+sysctl --system
+
+# Install docker engine
+{
+  apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  apt update
+  apt install -y docker-ce=5:19.03.10~3-0~ubuntu-focal containerd.io
+}
+
+# Add Apt repository
+{
+  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+  echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+}
+
+# Install Kubernetes components
+apt update && apt install -y kubeadm=1.18.5-00 kubelet=1.18.5-00 kubectl=1.18.5-00
+
+# In the end of installation, run
+# sudo kubeadm join 192.168.0.105:6443 --token a28itn.1jd9xmndf83z499n     --discovery-token-ca-cert-hash sha256:9c9f398f531ad04dc9f8b66600063bf03f4878fbb3e51c13ab276b5468ef3ae7


### PR DESCRIPTION
### Kubernetes package
---
`flavour` : `kubeadm`
create master and worker VMs
GB used is close to
- `1300 MB` in master
- `900-1100 MB` in worker

The FQDNs need to be different for the hosts.
In the worker installation file update the `hostname`
### Sequence
---
Install master first and then workers
Also scripts needs to be run in `sudo` mode.
After worker script is complete, copy last line from master script and run.
```
$ sudo kubeadm join 192.168.0.105:6443 --token a28itn.1jd9xmndf83z499n     --discovery-token-ca-cert-hash sha256:9c9f398f531ad04dc9f8b66600063bf03f4878fbb3e51c13ab276b5468ef3ae7
````
In the end to check proper installation, run in master
```
raktim@raktim-VirtualBox:~$ sudo kubectl get nodes
NAME       STATUS   ROLES    AGE    VERSION
kmaster    Ready    master   12m    v1.18.5
kworker1   Ready    <none>   5m3s   v1.18.5
kworker2   Ready    <none>   60s    v1.18.5
```