### PR TITLE
Added basic Makefiles

### DIFF
--- a/Makefile-golang
+++ b/Makefile-golang
@@ -1,0 +1,13 @@
+SOURCEFILE = prog.go
+TARGETFILE = vcs_prog
+
+hello:
+	echo "This is Makefile for Golang Binary"
+
+build:
+	go build -o bin/$(TARGETFILE) $(SOURCEFILE)
+
+run:
+	bin/$(TARGETFILE)
+
+all: hello build run

--- a/Makefile-nodejs
+++ b/Makefile-nodejs
@@ -1,0 +1,15 @@
+SOURCEFILE = prog.js
+TARGETFILE = vcs_prog
+
+hello:
+	echo "This is Makefile for Node.JS Binary"
+
+build:
+	sudo apt install npm -y
+	sudo npm install pkg
+	pkg $(SOURCEFILE) -t node10-linux-x64 -o $(TARGETFILE)
+
+run:
+	./$(TARGETFILE)
+
+all: hello build run

--- a/Makefile-python
+++ b/Makefile-python
@@ -1,0 +1,17 @@
+SOURCEFILE = prog.py
+TARGETFILE = vcs_prog
+
+hello:
+	echo "This is Makefile for Python Binary"
+
+build:
+	sudo apt install python3-dev -y
+	sudo apt install python3-pip -y
+	sudo pip3 install pyinstaller
+	pyinstaller --version
+	pyinstaller $(SOURCEFILE) --onefile --name dist/$(TARGETFILE)
+
+run:
+	dist/$(TARGETFILE)
+
+all: hello build run


### PR DESCRIPTION
### Basic Makefiles
---
`Makefile`s for `golang`, `python` and `nodejs`
These `Makefile`s can be used to build binaries.
Main file and Target binary files are to be updated before usage.
Also rename to `Makefile`
```
make build
make run
make all
```
N.B. need to add support to build binary for multiple OS.